### PR TITLE
adds method to get all interactions with particular bet

### DIFF
--- a/erc20_moc/Bet.noblock.js
+++ b/erc20_moc/Bet.noblock.js
@@ -11,6 +11,7 @@ const {
     insertReportChain,
     insertReport, viewReport,
     getBetInvestors,
+    getBetInteractions,
     getBetInvestorsChain,
 } = require('../utils/db_helper');
 
@@ -98,6 +99,13 @@ class Bet {
      * @returns {Promise<*>}
      */
     getUserAmmInteractions = async () => await getBetInvestors(this.betId);
+
+    /**
+     * Get all Investors of a Bet, broken by interaction type
+     *
+     * @returns {Promise<*>}
+     */
+     getBetInteractions = async () => await getBetInteractions(this.betId);
 
     /**
      * Get the OutcomeToken-Balances of a user


### PR DESCRIPTION
for the price display you can use a new `BetContract` method `getBetInteractions`. it returns a list of all interactions with a bet for all outcomes and all users. for a diagram
1. filter list for `BUY` directions (I assume you do buy price feed)
2. order list by `trx_timestamp`
3. group by `outcome` to have feeds per outcome
4. get price by dividing `investmentamount` by `outcometokensbought`